### PR TITLE
Release v1.6.1

### DIFF
--- a/Functions/CommonAliases.ps1
+++ b/Functions/CommonAliases.ps1
@@ -1,0 +1,6 @@
+# IISAdministration and WebAdministration compatible aliases
+New-Alias -Name Test-WebConfigFile -Value Test-PSWebConfig -Scope Script
+
+# Common aliases for application config scenarios
+New-Alias -Name Get-PSAppConfig -Value Get-PSWebConfig -Scope Script
+New-Alias -Name Test-PSAppConfig -Value Test-PSWebConfig -Scope Script

--- a/Functions/PSWebConfig/Test-PSWebConfig.ps1
+++ b/Functions/PSWebConfig/Test-PSWebConfig.ps1
@@ -29,8 +29,11 @@
 function Test-PSWebConfig {
     [CmdletBinding(DefaultParameterSetName="FromPipeLine")]
     param(
-        [Parameter(ParameterSetName="FromPipeLine",Position=0)]
-        [Parameter(ValueFromPipeLine=$true)]
+        [Parameter(
+            ParameterSetName="FromPipeLine",
+            ValueFromPipeLine=$true,
+            Position=0,
+            Mandatory=$true)]
         [psobject[]]$ConfigXml,
 
         [switch]$IncludeAppSettings,
@@ -38,6 +41,11 @@ function Test-PSWebConfig {
     )
     process {
         Write-Verbose "Executing Test-PSWebConfig"
+
+        if (-Not $ConfigXml.configuration) {
+            Write-Verbose "InputObject is not a valid XML configuration, trying to get config XML."
+            $ConfigXml = Get-PSWebConfig -InputObject $ConfigXml
+        }
 
         Get-PSUri -ConfigXml $ConfigXml -IncludeAppSettings:$IncludeAppSettings |
         Test-PSUri -Session $Session

--- a/PSWebConfig.psd1
+++ b/PSWebConfig.psd1
@@ -10,7 +10,7 @@
 RootModule = 'PSWebConfig.psm1'
 
 # Version number of this module.
-ModuleVersion = '1.6.0.0'
+ModuleVersion = '1.6.1.0'
 
 # ID used to uniquely identify this module
 GUID = '37abef2c-d883-46be-ce1a-53d16477d01d'
@@ -85,7 +85,11 @@ FunctionsToExport = @(
 # VariablesToExport = '*'
 
 # Aliases to export from this module
-# AliasesToExport = '*'
+AliasesToExport = @(
+    'Get-PSAppConfig'
+    'Test-PSAppConfig'
+    'Test-WebConfigFile'
+)
 
 # DSC resources to export from this module
 # DscResourcesToExport = @()
@@ -118,14 +122,15 @@ PrivateData = @{
             'config',
             'configuration',
             'section',
+            'IISAdministration',
             'WebAdministration'
         )
 
         # A URL to the license for this module.
-        LicenseUri = 'https://github.com/muratiakos/PSWebConfig/blob/master/LICENSE'
+        LicenseUri = 'https://github.com/murati-hu/PSWebConfig/blob/master/LICENSE'
 
         # A URL to the main website for this project.
-        ProjectUri = 'https://github.com/muratiakos/PSWebConfig'
+        ProjectUri = 'https://github.com/murati-hu/PSWebConfig'
 
         # A URL to an icon representing this module.
         # IconUri = ''
@@ -138,7 +143,7 @@ PrivateData = @{
 } # End of PrivateData hashtable
 
 # HelpInfo URI of this module
-HelpInfoURI = 'https://github.com/muratiakos/PSWebConfig'
+HelpInfoURI = 'https://github.com/murati-hu/PSWebConfig'
 
 # Default prefix for commands exported from this module. Override the default prefix using Import-Module -Prefix.
 # DefaultCommandPrefix = ''

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Get-PSWebConfig -Path C:\inetpub\wwwroot\
 ```
 ### Test config files
 `Test-PSWebConfig` function  allows complete tests on all connectionStrings and
-Service addresses from a configuration object both on local or remote computers.
+Service addresses from a configuration both on local or remote computers.
 ```powershell
-# Pipe Get-PSWebConfig into Test-PSWebConfig
-Get-Website * | Get-PSWebConfig | Test-PSWebConfig
+# Pipe a config into Test-PSWebConfig
+Get-Website * | Test-PSWebConfig
 
 # Or use -Session to test it via remote PSSession
 $server1 = New-PSSession 'server1.local.domain'
@@ -116,11 +116,11 @@ Created and maintained by [Akos Murati][muratiakos] (<akos@murati.hu>).
 ## License
 Apache License, Version 2.0 (see [LICENSE][LICENSE])
 
-[repo]: https://github.com/muratiakos/PSWebConfig
-[issues]: https://github.com/muratiakos/PSWebConfig/issues
+[repo]: https://github.com/murati-hu/PsWebConfig
+[issues]: https://github.com/murati-hu/PsWebConfig/issues
 [muratiakos]: http://murati.hu
 [license]: LICENSE
 [semver]: http://semver.org/
 [psget]: http://psget.net/
 [PowerShellGallery]: https://www.powershellgallery.com/packages/PSWebConfig
-[download]: https://github.com/muratiakos/PSWebConfig/archive/master.zip
+[download]: https://github.com/murati-hu/PSWebConfig/archive/master.zip

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ so you can simply install it with the following command:
 Install-Module PSWebConfig
 
 # Or alternatevely you can install it with PsGet from this repository
-Install-Module -ModuleUrl https://github.com/muratiakos/PSWebConfig/archive/master.zip
+Install-Module -ModuleUrl https://github.com/murati-hu/PSWebConfig/archive/master.zip
 ```
 Of course you can download and install the module manually too from
 [Downloads][download]

--- a/Tests/Module/Module.tests.ps1
+++ b/Tests/Module/Module.tests.ps1
@@ -4,7 +4,11 @@ $moduleName = 'PSWebConfig'
 $exportedCommands = (Get-Command -Module $moduleName)
 $expectedCommands = @(
     'Get-PSWebConfig'
+    'Get-PSAppConfig'
+
     'Test-PSWebConfig'
+    'Test-WebConfigFile'
+    'Test-PSAppConfig'
 
     'Get-PSAppSetting'
 


### PR DESCRIPTION
This release:
 - fixes configuration files  to be passed directly to `Test-PSWebConfig`
 - adds `AppConfig` aliases
 - moving git references to `murati-hu`

